### PR TITLE
경유지 삭제 처리 개선

### DIFF
--- a/src/main/java/com/cu2mber/stopoverservice/common/exception/StopoverErrorCode.java
+++ b/src/main/java/com/cu2mber/stopoverservice/common/exception/StopoverErrorCode.java
@@ -8,6 +8,7 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum StopoverErrorCode {
     BAD_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
+    STOPOVER_LIST_EMPTY(HttpStatus.BAD_REQUEST, "삭제할 경유지가 없습니다."),
     STOPOVER_CONFLICT(HttpStatus.CONFLICT, "이미 존재하는 경유지입니다."),
     STOPOVER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 경유지입니다."),
 

--- a/src/main/java/com/cu2mber/stopoverservice/dto/StopoverUpdateOrderRequest.java
+++ b/src/main/java/com/cu2mber/stopoverservice/dto/StopoverUpdateOrderRequest.java
@@ -11,9 +11,6 @@ import lombok.*;
 @EqualsAndHashCode
 public class StopoverUpdateOrderRequest {
 
-    @JsonProperty("no")
-    Long stopoverNo;
-
     @JsonProperty("order")
     int stopoverOrder;
 }

--- a/src/main/java/com/cu2mber/stopoverservice/dto/StopoverUpdateRequest.java
+++ b/src/main/java/com/cu2mber/stopoverservice/dto/StopoverUpdateRequest.java
@@ -10,9 +10,6 @@ import lombok.*;
 @EqualsAndHashCode
 public class StopoverUpdateRequest {
 
-    @JsonProperty("no")
-    Long stopoverNo;
-
     int localNo;
 
     @JsonProperty("name")

--- a/src/main/java/com/cu2mber/stopoverservice/service/StopoverService.java
+++ b/src/main/java/com/cu2mber/stopoverservice/service/StopoverService.java
@@ -15,9 +15,9 @@ public interface StopoverService {
 
     List<StopoverResponse> getStopoverList(int localNo);
 
-    StopoverResponse update(StopoverUpdateRequest request);
+    StopoverResponse update(Long stopoverNo, StopoverUpdateRequest request);
 
-    StopoverResponse updateOrder(StopoverUpdateOrderRequest request);
+    StopoverResponse updateOrder(Long stopoverNo, StopoverUpdateOrderRequest request);
 
     void delete(Long stopoverNo);
 

--- a/src/main/java/com/cu2mber/stopoverservice/service/impl/StopoverServiceImpl.java
+++ b/src/main/java/com/cu2mber/stopoverservice/service/impl/StopoverServiceImpl.java
@@ -50,8 +50,8 @@ public class StopoverServiceImpl implements StopoverService {
     }
 
     @Override
-    public StopoverResponse update(StopoverUpdateRequest request) {
-        Stopover stopover = stopoverRepository.findById(request.getStopoverNo())
+    public StopoverResponse update(Long stopoverNo, StopoverUpdateRequest request) {
+        Stopover stopover = stopoverRepository.findById(stopoverNo)
                 .orElseThrow(() -> new StopoverException(StopoverErrorCode.STOPOVER_NOT_FOUND, request.getStopoverName()));
 
         if(stopoverRepository.existsByLocalAndStopover(request.getLocalNo(), request.getStopoverName())) {
@@ -63,8 +63,8 @@ public class StopoverServiceImpl implements StopoverService {
     }
 
     @Override
-    public StopoverResponse updateOrder(StopoverUpdateOrderRequest request) {
-        Stopover stopover = stopoverRepository.findById(request.getStopoverNo())
+    public StopoverResponse updateOrder(Long stopoverNo, StopoverUpdateOrderRequest request) {
+        Stopover stopover = stopoverRepository.findById(stopoverNo)
                 .orElseThrow(() -> new StopoverException(StopoverErrorCode.STOPOVER_NOT_FOUND));
 
         stopover.updateOrder(request.getStopoverOrder());
@@ -82,9 +82,11 @@ public class StopoverServiceImpl implements StopoverService {
     public void deleteAll(int localNo) {
         List<Stopover> stopovers = stopoverRepository.findAllByLocalNo(localNo);
 
-        if(!stopovers.isEmpty()) {
-            stopovers.forEach(Stopover::delete);
+        if(stopovers.isEmpty()) {
+           throw new StopoverException(StopoverErrorCode.STOPOVER_LIST_EMPTY);
         }
+
+        stopovers.forEach(Stopover::delete);
 
     }
 

--- a/src/test/java/com/cu2mber/stopoverservice/service/impl/StopoverServiceImplTest.java
+++ b/src/test/java/com/cu2mber/stopoverservice/service/impl/StopoverServiceImplTest.java
@@ -111,8 +111,8 @@ class StopoverServiceImplTest {
         ReflectionTestUtils.setField(stopover, "stopoverNo", 1L);
         when(stopoverRepository.findById(Mockito.anyLong())).thenReturn(Optional.of(stopover));
 
-        StopoverUpdateRequest request = new StopoverUpdateRequest(1L, 1, "김해대");
-        StopoverResponse response = stopoverService.update(request);
+        StopoverUpdateRequest request = new StopoverUpdateRequest(1, "김해대");
+        StopoverResponse response = stopoverService.update(1L, request);
         assertEquals(1L, response.getStopoverNo());
         assertEquals("김해대", response.getStopoverName());
 
@@ -127,8 +127,8 @@ class StopoverServiceImplTest {
         when(stopoverRepository.findById(Mockito.anyLong())).thenReturn(Optional.of(stopover));
         when(stopoverRepository.existsByLocalAndStopover(Mockito.anyInt(), Mockito.anyString())).thenReturn(true);
 
-        StopoverUpdateRequest request = new StopoverUpdateRequest(1L, 1, "인제대");
-        assertThrows(StopoverException.class, () -> stopoverService.update(request));
+        StopoverUpdateRequest request = new StopoverUpdateRequest(1, "인제대");
+        assertThrows(StopoverException.class, () -> stopoverService.update(1L, request));
 
         verify(stopoverRepository, Mockito.times(1)).findById(Mockito.anyLong());
         verify(stopoverRepository, Mockito.times(1)).existsByLocalAndStopover(Mockito.anyInt(), Mockito.anyString());
@@ -141,8 +141,8 @@ class StopoverServiceImplTest {
         ReflectionTestUtils.setField(stopover, "stopoverNo", 1L);
         when(stopoverRepository.findById(Mockito.anyLong())).thenReturn(Optional.of(stopover));
 
-        StopoverUpdateOrderRequest request = new StopoverUpdateOrderRequest(1L, 3);
-        StopoverResponse response = stopoverService.updateOrder(request);
+        StopoverUpdateOrderRequest request = new StopoverUpdateOrderRequest(3);
+        StopoverResponse response = stopoverService.updateOrder(1L, request);
         assertEquals(3, response.getStopoverOrder());
 
         verify(stopoverRepository, Mockito.times(1)).findById(Mockito.anyLong());
@@ -180,5 +180,16 @@ class StopoverServiceImplTest {
         assertEquals(2, responseList.size());
         assertTrue(responseList.getFirst().isStopoverDeletion());
         assertTrue(responseList.get(1).isStopoverDeletion());
+    }
+
+    @Test
+    @DisplayName("경유지 삭제(지자체) - 리스트가 빈 경우")
+    void deleteAll_empty() {
+        when(stopoverRepository.findAllByLocalNo(Mockito.anyInt())).thenReturn(List.of());
+
+        assertThrows(StopoverException.class, () -> stopoverService.deleteAll(1));
+
+        verify(stopoverRepository, Mockito.times(1)).findAllByLocalNo(Mockito.anyInt());
+
     }
 }


### PR DESCRIPTION
## 📌 관련 이슈

- close #2 

## ✨ 변경 내용

- 삭제시 예외처리
- DTO 변경  
  - 기존 DTO에는 `stopoverNo`가 있었으나, 컨트롤러 구현 과정에서 불필요할 것으로 판단되어 삭제함  

## ✅ 체크리스트

- [x] 빌드 및 테스트가 모두 통과했나요?
- [x] merge할 branch를 확인했나요? (예: `develop` → `main`)
- [x] Assignee를 지정했나요?
- [x] 코드 리뷰어를 지정했나요? (필요 시)

## 📝 기타 참고 사항

- 경유지 삭제는 소프트 삭제 방식으로, 기존 이슈와 동일한 구조를 유지합니다.
- 따라서 주요 기능상의 변경은 없습니다.